### PR TITLE
Added support for virtual products

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ There are two tiers in this shipping method:
 __Base fee:__ This is the base (default) flat shipping fee that is applied automatically to the cart total for any number of items.
 
 __Tiered fee:__ This is the additional shipping fee that is added to the base fee if the number of items in the user's cart exceeds a specified number.  This tiered fee can either be a flat fee, meaning that it is applied to carts of any size above the specified tier quantity, or a progressive fee, meaning that the tier quantity is used as a multiplier to the tiered fee.
+
+Virtual products
+----------------
+
+Products that cannot be shipped, such as digital downloads or other intangible goods, should be marked as virtual in WooCommerce. Virtual products are ignored when calculating the shipping fee.

--- a/wc-tiered-shipping/wc-tiered-shipping.php
+++ b/wc-tiered-shipping/wc-tiered-shipping.php
@@ -123,9 +123,17 @@ function tiered_shipping_init() {
 				if ($this->is_tiered_allowed($package)) { 
 					global $woocommerce;
 
-					// Get total item count from cart.
-					$cart_item_quantities = $woocommerce->cart->get_cart_item_quantities();
-					$cart_total_items = array_sum($cart_item_quantities); 
+					// Get all items from cart.
+					$items = $woocommerce->cart->get_cart();
+					$cart_total_items = 0;
+
+					// Sum non-virtual (i.e. shippable) items
+					foreach ($items as $item) {
+						$product = wc_get_product($item['product_id']);
+						if (!$product->is_virtual()) {
+							$cart_total_items += $item['quantity'];
+						}
+					}
 					
 					// Set the base shipping fee.
 					$shipping = $this->get_option('basefee');


### PR DESCRIPTION
Previously, virtual products such as digital downloads and other intangible goods counted toward tiered pricing. This change excludes those items from shipping fee calculation.