### PR TITLE
Do not charge the base fee if there are no items to ship.

### DIFF
--- a/wc-tiered-shipping/wc-tiered-shipping.php
+++ b/wc-tiered-shipping/wc-tiered-shipping.php
@@ -128,7 +128,7 @@ function tiered_shipping_init() {
 					$cart_total_items = array_sum($cart_item_quantities); 
 					
 					// Set the base shipping fee.
-					$shipping = $this->get_option('basefee');
+					$shipping = $cart_total_items > 0 ? $this->get_option('basefee') : 0;
 					
 					// Override base fee with tiered fee if cart items are over the tier quantity.
 					if ($cart_total_items > $this->get_option('quantity')) {


### PR DESCRIPTION
Particularly when a store offers virtual goods there may not be any items in the cart for which a shipping fee should apply. When there are zero items, set the shipping fee to zero as well.